### PR TITLE
Use RUNNER_TEMP as the temporary directory.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,13 +22,13 @@ runs:
   - name: Download Swift
     shell: pwsh
     run: |
-      If (test-path "$env:TEMP/swift-installer.exe") {
+      If (test-path "$env:RUNNER_TEMP/swift-installer.exe") {
       } else {
-        curl -o "$env:TEMP/swift-installer.exe" https://swift.org/builds/swift-${{ inputs.version }}-release/windows10/swift-${{ inputs.version }}-RELEASE/swift-${{ inputs.version }}-RELEASE-windows10.exe
+        curl -o "$env:RUNNER_TEMP/swift-installer.exe" https://swift.org/builds/swift-${{ inputs.version }}-release/windows10/swift-${{ inputs.version }}-RELEASE/swift-${{ inputs.version }}-RELEASE-windows10.exe
       }
   - name: Install Swift
     shell: pwsh
-    run: Start-Process -Wait -FilePath "$env:TEMP/swift-installer.exe" -ArgumentList ("/quiet", "/norestart")
+    run: Start-Process -Wait -FilePath "$env:RUNNER_TEMP/swift-installer.exe" -ArgumentList ("/quiet", "/norestart")
   - name: Set Environment Variables
     shell: pwsh
     run: |


### PR DESCRIPTION
Using the `$env:TEMP` path was failing, claiming a corrupted directory. The GitHub documentation pointed me to [RUNNER_TEMP](https://docs.github.com/en/actions/learn-github-actions/variables)

```
Run Start-Process -Wait -FilePath "$env:TEMP/swift-installer.exe" -ArgumentList ("/quiet", "/norestart")
Start-Process: D:\a\_temp\09b84b21-28ed-449b-a853-29fe0d6c5ffb.ps1:2
Line |
   2 |  Start-Process -Wait -FilePath "$env:TEMP/swift-installer.exe" -Argume …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | This command cannot be run due to the error: An error occurred trying to start process
     | 'C:\Users\RUNNER~1\AppData\Local\Temp\swift-installer.exe' with working directory 'D:\a\foo\bar'.
     | The file or directory is corrupted and unreadable.